### PR TITLE
avoid upload if file is 0 bytes

### DIFF
--- a/src/server/webdav/tgfs-filesystem.ts
+++ b/src/server/webdav/tgfs-filesystem.ts
@@ -273,6 +273,11 @@ export class TGFSFileSystem extends VirtualFileSystem {
 
         callback(null, stream);
 
+        if ( estimatedSize <= 0 ) {
+          Logger.info('skip upload because file is 0 bytes');
+          return;
+        }
+
         try {
           // this.resources[path.toString()] = new TGFSFileResource({
           //   size: estimatedSize,


### PR DESCRIPTION
rclone mount performs a "test" before uploading file. It tries to write a 0bytes file just to check the folder permissions.
tgfs gets the request and tries to upload an emty file: telegram crashes for "FILE_PART_MISSING" .

This fix just skips the upload if file is 0bytes