### PR TITLE
feat(telegram): opt-in deletion of channel messages on remove

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Refer to the [wiki page](https://github.com/TheodoreKrypton/tgfs/wiki/TGFS-Wiki)
 * Importing files that are already on Telegram (Only via the Telegram Mini App)
 * File size is unlimited (larger files are chunked into parts but appear as a single file to the user)
 * Live streaming of videos
+* Optional deletion of the underlying Telegram messages when removing files or folders (opt-in via `delete_messages_on_remove`)
 
 
 ## Demo Server

--- a/demo-config.yaml
+++ b/demo-config.yaml
@@ -7,6 +7,14 @@ telegram:
       - hidden
   private_file_channel: 'tgfsdemo'
   lib: pyrogram
+  # When ``true``, removing a file (or directory) through TGFS also issues
+  # ``messages.deleteMessages`` for every backing message in the channel:
+  # the JSON file-descriptor message and every content message of every
+  # version. Default is ``false`` -- metadata is updated but the original
+  # messages stay in the channel, matching historical behavior.
+  # The bot account must be an admin of ``private_file_channel`` with the
+  # "Delete Messages" permission for this to succeed.
+  delete_messages_on_remove: false
 tgfs:
   users:
   download:

--- a/tests/tgfs/core/api/message/test_message_api.py
+++ b/tests/tgfs/core/api/message/test_message_api.py
@@ -13,6 +13,7 @@ from tgfs.errors import (
     TechnicalError,
 )
 from tgfs.reqres import (
+    DeleteMessagesReq,
     DownloadFileReq,
     DownloadFileResp,
     EditMessageTextReq,
@@ -41,6 +42,7 @@ class TestMessageApi:
         tdlib.next_bot.edit_message_text = AsyncMock()
         tdlib.next_bot.pin_message = AsyncMock()
         tdlib.next_bot.download_file = AsyncMock()
+        tdlib.next_bot.delete_messages = AsyncMock()
         tdlib.account.get_pinned_messages = AsyncMock()
         tdlib.account.search_messages = AsyncMock()
 
@@ -333,6 +335,89 @@ class TestMessageApi:
         assert (
             result.size == -98
         )  # Note: This reflects the _size method behavior (0 - 99 + 1 = -98)
+
+    @pytest.fixture
+    def patch_delete_flag(self, mocker):
+        def _patch(enabled: bool):
+            cfg = mocker.Mock()
+            cfg.telegram.delete_messages_on_remove = enabled
+            mocker.patch("tgfs.core.api.message.get_config", return_value=cfg)
+
+        return _patch
+
+    @pytest.mark.asyncio
+    async def test_delete_messages_disabled_no_call(
+        self, message_api, mock_tdlib, patch_delete_flag
+    ):
+        patch_delete_flag(False)
+
+        await message_api.delete_messages([1, 2, 3])
+
+        mock_tdlib.next_bot.delete_messages.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_delete_messages_enabled(
+        self, message_api, mock_tdlib, mock_private_channel, patch_delete_flag
+    ):
+        patch_delete_flag(True)
+
+        await message_api.delete_messages([10, 20, 30])
+
+        mock_tdlib.next_bot.delete_messages.assert_called_once()
+        req: DeleteMessagesReq = (
+            mock_tdlib.next_bot.delete_messages.call_args[0][0]
+        )
+        assert req.chat == mock_private_channel
+        assert set(req.message_ids) == {10, 20, 30}
+
+    @pytest.mark.asyncio
+    async def test_delete_messages_empty_no_call(
+        self, message_api, mock_tdlib, patch_delete_flag
+    ):
+        patch_delete_flag(True)
+
+        await message_api.delete_messages([])
+        await message_api.delete_messages([0, -1])
+
+        mock_tdlib.next_bot.delete_messages.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_delete_messages_dedupes(
+        self, message_api, mock_tdlib, patch_delete_flag
+    ):
+        patch_delete_flag(True)
+
+        await message_api.delete_messages([5, 5, 5, 6])
+
+        assert mock_tdlib.next_bot.delete_messages.call_count == 1
+        req = mock_tdlib.next_bot.delete_messages.call_args[0][0]
+        assert sorted(req.message_ids) == [5, 6]
+
+    @pytest.mark.asyncio
+    async def test_delete_messages_batches_above_limit(
+        self, message_api, mock_tdlib, patch_delete_flag
+    ):
+        patch_delete_flag(True)
+
+        ids = list(range(1, 251))  # 250 ids -> 100 + 100 + 50
+        await message_api.delete_messages(ids)
+
+        assert mock_tdlib.next_bot.delete_messages.call_count == 3
+        sizes = [
+            len(call.args[0].message_ids)
+            for call in mock_tdlib.next_bot.delete_messages.call_args_list
+        ]
+        assert sorted(sizes) == [50, 100, 100]
+
+    @pytest.mark.asyncio
+    async def test_delete_messages_swallows_errors(
+        self, message_api, mock_tdlib, patch_delete_flag
+    ):
+        patch_delete_flag(True)
+        mock_tdlib.next_bot.delete_messages.side_effect = RuntimeError("boom")
+
+        # Should not raise.
+        await message_api.delete_messages([1, 2])
 
     @pytest.mark.asyncio
     async def test_download_file_end_zero_or_negative(self, message_api, mock_tdlib):

--- a/tests/tgfs/core/api/test_directory.py
+++ b/tests/tgfs/core/api/test_directory.py
@@ -1,0 +1,82 @@
+import datetime
+
+import pytest
+
+from tgfs.core.api.directory import DirectoryApi
+from tgfs.core.api.file import FileApi
+from tgfs.core.api.message import MessageApi
+from tgfs.core.api.metadata import MetaDataApi
+from tgfs.core.model import TGFSDirectory, TGFSFileRef, TGFSFileVersion
+from tgfs.errors import DirectoryIsNotEmpty
+
+
+class TestDirectoryApi:
+    @pytest.fixture
+    def mock_metadata_api(self, mocker):
+        return mocker.AsyncMock(spec=MetaDataApi)
+
+    @pytest.fixture
+    def mock_file_api(self, mocker):
+        return mocker.AsyncMock(spec=FileApi)
+
+    @pytest.fixture
+    def mock_message_api(self, mocker):
+        return mocker.AsyncMock(spec=MessageApi)
+
+    @pytest.fixture
+    def dir_api(self, mock_metadata_api, mock_file_api, mock_message_api) -> DirectoryApi:
+        return DirectoryApi(mock_metadata_api, mock_file_api, mock_message_api)
+
+    @staticmethod
+    def _make_version(message_ids):
+        return TGFSFileVersion(
+            id="v1",
+            updated_at=datetime.datetime.now(),
+            message_ids=list(message_ids),
+        )
+
+    @pytest.mark.asyncio
+    async def test_rm_empty_directory_no_messages_to_delete(
+        self, dir_api, mock_metadata_api, mock_message_api
+    ):
+        empty_dir = TGFSDirectory.root_dir()
+
+        await dir_api.rm_empty(empty_dir)
+
+        mock_metadata_api.push.assert_called_once()
+        mock_message_api.delete_messages.assert_called_once_with([])
+
+    @pytest.mark.asyncio
+    async def test_rm_empty_non_empty_raises(self, dir_api):
+        d = TGFSDirectory.root_dir()
+        d.create_file_ref("a.txt", 1)
+
+        with pytest.raises(DirectoryIsNotEmpty):
+            await dir_api.rm_empty(d)
+
+    @pytest.mark.asyncio
+    async def test_rm_dangerously_collects_subtree_message_ids(
+        self, dir_api, mock_file_api, mock_message_api, mock_metadata_api
+    ):
+        root = TGFSDirectory.root_dir()
+        root.create_file_ref("top.txt", 10)
+
+        sub = root.create_dir("sub", None)
+        sub.create_file_ref("inner.txt", 20)
+
+        async def fake_collect(fr: TGFSFileRef):
+            # Real impl returns the FD message id plus version content ids.
+            if fr.message_id == 10:
+                return [10, 100, 101]
+            if fr.message_id == 20:
+                return [20, 200]
+            return []
+
+        mock_file_api.collect_message_ids.side_effect = fake_collect
+
+        await dir_api.rm_dangerously(root)
+
+        mock_metadata_api.push.assert_called_once()
+        mock_message_api.delete_messages.assert_called_once()
+        deleted = mock_message_api.delete_messages.call_args[0][0]
+        assert sorted(deleted) == [10, 20, 100, 101, 200]

--- a/tests/tgfs/core/api/test_file.py
+++ b/tests/tgfs/core/api/test_file.py
@@ -3,6 +3,7 @@ import datetime
 
 from tgfs.core.api.file import FileApi
 from tgfs.core.api.file_desc import FileDescApi
+from tgfs.core.api.message import MessageApi
 from tgfs.core.api.metadata import MetaDataApi
 from tgfs.core.model import TGFSDirectory, TGFSFileDesc, TGFSFileRef, TGFSFileVersion
 from tgfs.errors import FileOrDirectoryDoesNotExist
@@ -23,8 +24,14 @@ class TestFileApi:
         return mocker.AsyncMock(spec=FileDescApi)
 
     @pytest.fixture
-    def file_api(self, mock_metadata_api, mock_file_desc_api) -> FileApi:
-        return FileApi(mock_metadata_api, mock_file_desc_api)
+    def mock_message_api(self, mocker):
+        return mocker.AsyncMock(spec=MessageApi)
+
+    @pytest.fixture
+    def file_api(
+        self, mock_metadata_api, mock_file_desc_api, mock_message_api
+    ) -> FileApi:
+        return FileApi(mock_metadata_api, mock_file_desc_api, mock_message_api)
 
     @pytest.fixture
     def sample_directory(self) -> TGFSDirectory:
@@ -52,11 +59,12 @@ class TestFileApi:
     def sample_file_message(self) -> FileMessageFromBuffer:
         return FileMessageFromBuffer.new(buffer=b"test content", name="test_file.txt")
 
-    def test_init(self, mock_metadata_api, mock_file_desc_api):
-        file_api = FileApi(mock_metadata_api, mock_file_desc_api)
+    def test_init(self, mock_metadata_api, mock_file_desc_api, mock_message_api):
+        file_api = FileApi(mock_metadata_api, mock_file_desc_api, mock_message_api)
 
         assert file_api._metadata_api == mock_metadata_api
         assert file_api._file_desc_api == mock_file_desc_api
+        assert file_api._message_api == mock_message_api
 
     @pytest.mark.asyncio
     async def test_copy_with_custom_name(
@@ -182,18 +190,42 @@ class TestFileApi:
 
     @pytest.mark.asyncio
     async def test_rm_without_version_id(
-        self, file_api, mock_metadata_api, sample_file_ref, mocker
+        self,
+        file_api,
+        mock_metadata_api,
+        mock_message_api,
+        mock_file_desc_api,
+        sample_file_ref,
+        mocker,
     ):
         sample_file_ref.delete = mocker.Mock()
+
+        fd = mocker.Mock(spec=TGFSFileDesc)
+        fd.get_versions.return_value = [
+            TGFSFileVersion(
+                id="v1",
+                updated_at=datetime.datetime.now(),
+                message_ids=[200, 201],
+            )
+        ]
+        mock_file_desc_api.get_file_desc.return_value = fd
 
         await file_api.rm(sample_file_ref)
 
         sample_file_ref.delete.assert_called_once()
         mock_metadata_api.push.assert_called_once()
+        mock_message_api.delete_messages.assert_called_once()
+        deleted_ids = mock_message_api.delete_messages.call_args[0][0]
+        assert sorted(deleted_ids) == [123, 200, 201]
 
     @pytest.mark.asyncio
     async def test_rm_with_version_id(
-        self, file_api, mock_file_desc_api, sample_file_ref, mocker
+        self,
+        file_api,
+        mock_file_desc_api,
+        mock_message_api,
+        sample_file_ref,
+        mocker,
     ):
         version_id = "v1"
         mock_response = mocker.Mock()
@@ -203,12 +235,21 @@ class TestFileApi:
         mock_file_desc_api.delete_file_version.return_value = mock_response
         sample_file_ref.delete = mocker.Mock()
 
+        fd = mocker.Mock(spec=TGFSFileDesc)
+        fd.get_version.return_value = TGFSFileVersion(
+            id=version_id,
+            updated_at=datetime.datetime.now(),
+            message_ids=[500, 501],
+        )
+        mock_file_desc_api.get_file_desc.return_value = fd
+
         await file_api.rm(sample_file_ref, version_id)
 
         mock_file_desc_api.delete_file_version.assert_called_once_with(
             sample_file_ref, version_id
         )
         sample_file_ref.delete.assert_not_called()
+        mock_message_api.delete_messages.assert_called_once_with([500, 501])
 
     @pytest.mark.asyncio
     async def test_upload_non_uploadable_message_new_file(
@@ -494,6 +535,14 @@ class TestFileApi:
         mock_response = mocker.Mock()
         mock_response.message_id = new_message_id  # Different ID, update needed
         mock_file_desc_api.delete_file_version.return_value = mock_response
+
+        fd = mocker.Mock(spec=TGFSFileDesc)
+        fd.get_version.return_value = TGFSFileVersion(
+            id=version_id,
+            updated_at=datetime.datetime.now(),
+            message_ids=[],
+        )
+        mock_file_desc_api.get_file_desc.return_value = fd
 
         await file_api.rm(sample_file_ref, version_id)
 

--- a/tests/tgfs/telegram/impl/test_telethon.py
+++ b/tests/tgfs/telegram/impl/test_telethon.py
@@ -16,6 +16,7 @@ from tgfs.telegram.impl.telethon import (
 from tgfs.config import Config, TelegramConfig, BotConfig, AccountConfig
 from tgfs.errors import TechnicalError, UnDownloadableMessage
 from tgfs.reqres import (
+    DeleteMessagesReq,
     GetMessagesReq,
     SendTextReq,
     EditMessageTextReq,
@@ -42,6 +43,7 @@ class TestTelethonAPI:
         client.send_file = mocker.AsyncMock()
         client.pin_message = mocker.AsyncMock()
         client.iter_download = mocker.AsyncMock()
+        client.delete_messages = mocker.AsyncMock()
         return client
 
     @pytest.fixture
@@ -323,6 +325,31 @@ class TestTelethonAPI:
         assert call_args[1]["entity"] == tlt.PeerChannel(mock_chat)
         assert isinstance(call_args[1]["filter"], tlt.InputMessagesFilterPinned)
         assert len(result) >= 0
+
+    @pytest.mark.asyncio
+    async def test_delete_messages(self, telethon_api, mock_chat, mocker):
+        mock_cache = mocker.Mock()
+        mock_cache.__setitem__ = mocker.Mock()
+
+        mock_channel_cache = mocker.patch("tgfs.telegram.impl.telethon.channel_cache")
+        mock_cache_instance = mocker.Mock()
+        mock_cache_instance.id = mock_cache
+        mock_channel_cache.return_value = mock_cache_instance
+
+        req = DeleteMessagesReq(chat=mock_chat, message_ids=(11, 22, 33))
+        await telethon_api.delete_messages(req)
+
+        telethon_api._client.delete_messages.assert_called_once_with(
+            entity=tlt.PeerChannel(channel_id=mock_chat), message_ids=[11, 22, 33]
+        )
+        assert mock_cache.__setitem__.call_count == 3
+
+    @pytest.mark.asyncio
+    async def test_delete_messages_empty_is_noop(self, telethon_api, mock_chat):
+        req = DeleteMessagesReq(chat=mock_chat, message_ids=())
+        await telethon_api.delete_messages(req)
+
+        telethon_api._client.delete_messages.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_pin_message(self, telethon_api, mock_chat):

--- a/tgfs/config.py
+++ b/tgfs/config.py
@@ -205,6 +205,7 @@ class TelegramConfig:
     bot: BotConfig
     private_file_channel: List[str]
     lib: Literal["pyrogram", "telethon"]
+    delete_messages_on_remove: bool
 
     @classmethod
     def from_dict(cls, data: dict) -> "TelegramConfig":
@@ -217,6 +218,9 @@ class TelegramConfig:
             bot=BotConfig.from_dict(data["bot"]),
             private_file_channel=data["private_file_channel"],
             lib=data.get("lib") or "telethon",
+            delete_messages_on_remove=bool(
+                data.get("delete_messages_on_remove", False)
+            ),
         )
 
 

--- a/tgfs/core/api/directory.py
+++ b/tgfs/core/api/directory.py
@@ -3,12 +3,21 @@ from typing import List, Optional
 from tgfs.core.model import TGFSDirectory, TGFSFileRef
 from tgfs.errors import DirectoryIsNotEmpty, FileOrDirectoryDoesNotExist
 
+from .file import FileApi
+from .message import MessageApi
 from .metadata import MetaDataApi
 
 
 class DirectoryApi:
-    def __init__(self, metadata_api: MetaDataApi):
+    def __init__(
+        self,
+        metadata_api: MetaDataApi,
+        file_api: FileApi,
+        message_api: MessageApi,
+    ):
         self.__metadata_api = metadata_api
+        self.__file_api = file_api
+        self.__message_api = message_api
 
     @property
     def root(self):
@@ -40,5 +49,17 @@ class DirectoryApi:
         await self.rm_dangerously(directory)
 
     async def rm_dangerously(self, directory: TGFSDirectory) -> None:
+        message_ids = await self.__collect_subtree_message_ids(directory)
         directory.delete()
         await self.__metadata_api.push()
+        await self.__message_api.delete_messages(message_ids)
+
+    async def __collect_subtree_message_ids(
+        self, directory: TGFSDirectory
+    ) -> List[int]:
+        ids: List[int] = []
+        for fr in directory.find_files():
+            ids.extend(await self.__file_api.collect_message_ids(fr))
+        for child in directory.find_dirs():
+            ids.extend(await self.__collect_subtree_message_ids(child))
+        return ids

--- a/tgfs/core/api/file.py
+++ b/tgfs/core/api/file.py
@@ -1,4 +1,5 @@
-from typing import Optional
+import logging
+from typing import List, Optional
 
 from tgfs.core.model import TGFSDirectory, TGFSFileDesc, TGFSFileRef, TGFSFileVersion
 from tgfs.errors import FileOrDirectoryDoesNotExist
@@ -9,13 +10,58 @@ from tgfs.reqres import (
 )
 
 from .file_desc import FileDescApi
+from .message import MessageApi
 from .metadata import MetaDataApi
+
+logger = logging.getLogger(__name__)
 
 
 class FileApi:
-    def __init__(self, metadata_api: MetaDataApi, file_desc_api: FileDescApi):
+    def __init__(
+        self,
+        metadata_api: MetaDataApi,
+        file_desc_api: FileDescApi,
+        message_api: MessageApi,
+    ):
         self._metadata_api = metadata_api
         self._file_desc_api = file_desc_api
+        self._message_api = message_api
+
+    async def collect_message_ids(self, fr: TGFSFileRef) -> List[int]:
+        """Return every channel message id backing ``fr``.
+
+        Includes the file descriptor message itself plus every content
+        message across all known versions. Returns just the descriptor
+        id if the descriptor can no longer be read (it may already be
+        gone), so callers can still try to delete that one message.
+        """
+        ids: List[int] = []
+        if fr.message_id > 0:
+            ids.append(fr.message_id)
+        try:
+            fd = await self._file_desc_api.get_file_desc(fr)
+        except Exception as ex:
+            logger.warning(
+                f"Could not load file descriptor for {fr.name} "
+                f"(message_id={fr.message_id}): {ex}"
+            )
+            return ids
+        for version in fd.get_versions():
+            ids.extend(mid for mid in version.message_ids if mid > 0)
+        return ids
+
+    async def _collect_version_message_ids(
+        self, fr: TGFSFileRef, version_id: str
+    ) -> List[int]:
+        try:
+            fd = await self._file_desc_api.get_file_desc(fr)
+            version = fd.get_version(version_id)
+        except Exception as ex:
+            logger.warning(
+                f"Could not load version {version_id} of {fr.name}: {ex}"
+            )
+            return []
+        return [mid for mid in version.message_ids if mid > 0]
 
     async def copy(
         self, where: TGFSDirectory, fr: TGFSFileRef, name: Optional[str] = None
@@ -57,11 +103,15 @@ class FileApi:
 
     async def rm(self, fr: TGFSFileRef, version_id: Optional[str] = None) -> None:
         if not version_id:
+            message_ids = await self.collect_message_ids(fr)
             fr.delete()
             await self._metadata_api.push()
+            await self._message_api.delete_messages(message_ids)
         else:
+            message_ids = await self._collect_version_message_ids(fr, version_id)
             resp = await self._file_desc_api.delete_file_version(fr, version_id)
             await self._update_file_ref_message_id_if_necessary(fr, resp.message_id)
+            await self._message_api.delete_messages(message_ids)
 
     async def upload(
         self,

--- a/tgfs/core/api/message/__init__.py
+++ b/tgfs/core/api/message/__init__.py
@@ -1,5 +1,6 @@
 import asyncio
-from typing import Iterator
+import logging
+from typing import Iterable, Iterator, List
 
 from pyrate_limiter import Duration, InMemoryBucket, Limiter, Rate
 from telethon.errors import MessageNotModifiedError, RPCError
@@ -12,6 +13,7 @@ from tgfs.errors import (
     TechnicalError,
 )
 from tgfs.reqres import (
+    DeleteMessagesReq,
     DownloadFileReq,
     DownloadFileResp,
     EditMessageTextReq,
@@ -27,6 +29,11 @@ from tgfs.utils.chained_async_iterator import ChainedAsyncIterator
 from tgfs.utils.others import exclude_none, is_big_file
 
 from .message_broker import MessageBroker
+
+logger = logging.getLogger(__name__)
+
+# Telegram's messages.deleteMessages caps each request at 100 message ids.
+DELETE_BATCH_SIZE = 100
 
 rate = Rate(20, Duration.SECOND)
 bucket = InMemoryBucket([rate])
@@ -90,6 +97,36 @@ class MessageApi(MessageBroker):
             document=message.document,
             text="",
         )
+
+    async def delete_messages(self, message_ids: Iterable[int]) -> None:
+        """Best-effort deletion of channel messages.
+
+        Gated by ``telegram.delete_messages_on_remove`` so the default
+        TGFS behavior (file removed from metadata, message kept on the
+        channel) is unchanged. Failures are logged but never raised --
+        the caller has already committed the metadata change and we do
+        not want a delete error to roll that back.
+        """
+        if not get_config().telegram.delete_messages_on_remove:
+            return
+        unique_ids: List[int] = list({mid for mid in message_ids if mid > 0})
+        if not unique_ids:
+            return
+        for start in range(0, len(unique_ids), DELETE_BATCH_SIZE):
+            batch = tuple(unique_ids[start : start + DELETE_BATCH_SIZE])
+            self.__try_acquire("MessageApi.delete_messages")
+            try:
+                await self.tdlib.next_bot.delete_messages(
+                    DeleteMessagesReq(
+                        chat=self.private_file_channel,
+                        message_ids=batch,
+                    )
+                )
+            except Exception as ex:
+                logger.warning(
+                    f"Failed to delete telegram messages {batch} from channel "
+                    f"{self.private_file_channel}: {ex}"
+                )
 
     async def pin_message(self, message_id: int):
         self.__try_acquire("MessageApi.pin_message")

--- a/tgfs/core/client.py
+++ b/tgfs/core/client.py
@@ -65,8 +65,8 @@ class Client:
         metadata_api = MetaDataApi(metadata_repo)
         await metadata_api.init()
 
-        file_api = FileApi(metadata_api, fd_api)
-        dir_api = DirectoryApi(metadata_api)
+        file_api = FileApi(metadata_api, fd_api, message_api)
+        dir_api = DirectoryApi(metadata_api, file_api, message_api)
 
         return cls(
             name=metadata_cfg.name,

--- a/tgfs/reqres.py
+++ b/tgfs/reqres.py
@@ -55,6 +55,11 @@ class SearchMessageReq(Chat):
     search: str
 
 
+@dataclass
+class DeleteMessagesReq(Chat):
+    message_ids: Tuple[int, ...]
+
+
 GetPinnedMessageReq = Chat
 SendMessageResp = Message
 

--- a/tgfs/telegram/impl/pyrogram.py
+++ b/tgfs/telegram/impl/pyrogram.py
@@ -12,6 +12,7 @@ from pyrogram.raw import types as rt
 from tgfs.config import Config
 from tgfs.errors import TechnicalError, UnDownloadableMessage
 from tgfs.reqres import (
+    DeleteMessagesReq,
     Document,
     DownloadFileReq,
     DownloadFileResp,
@@ -276,6 +277,16 @@ class PyrogramAPI(ITDLibClient):
                         break
 
         return DownloadFileResp(chunks=chunks(), size=bytes_to_read)
+
+    async def delete_messages(self, req: DeleteMessagesReq) -> None:
+        if not req.message_ids:
+            return
+        cache = channel_cache(req.chat).id
+        for mid in req.message_ids:
+            cache[mid] = None
+        await self._client.delete_messages(
+            chat_id=req.chat, message_ids=list(req.message_ids)
+        )
 
     async def resolve_channel_id(self, channel_id: str) -> int:
         try:

--- a/tgfs/telegram/impl/telethon.py
+++ b/tgfs/telegram/impl/telethon.py
@@ -14,6 +14,7 @@ from telethon.tl.types import InputDocumentFileLocation, PeerChannel
 from tgfs.config import Config
 from tgfs.errors import TechnicalError, UnDownloadableMessage
 from tgfs.reqres import (
+    DeleteMessagesReq,
     Document,
     DownloadFileReq,
     DownloadFileResp,
@@ -255,6 +256,17 @@ class TelethonAPI(ITDLibClient):
                     break
 
         return DownloadFileResp(chunks=chunks(), size=bytes_to_read)
+
+    async def delete_messages(self, req: DeleteMessagesReq) -> None:
+        if not req.message_ids:
+            return
+        cache = channel_cache(req.chat).id
+        for mid in req.message_ids:
+            cache[mid] = None
+        await self._client.delete_messages(
+            entity=PeerChannel(channel_id=req.chat),
+            message_ids=list(req.message_ids),
+        )
 
     async def resolve_channel_id(self, channel_id: str) -> int:
         try:

--- a/tgfs/telegram/interface.py
+++ b/tgfs/telegram/interface.py
@@ -4,6 +4,7 @@ from itertools import cycle
 from typing import Optional, Sequence
 
 from tgfs.reqres import (
+    DeleteMessagesReq,
     DownloadFileReq,
     DownloadFileResp,
     EditMessageMediaReq,
@@ -77,6 +78,10 @@ class ITDLibClient(metaclass=ABCMeta):
 
     @abstractmethod
     async def download_file(self, req: DownloadFileReq) -> DownloadFileResp:
+        pass
+
+    @abstractmethod
+    async def delete_messages(self, req: DeleteMessagesReq) -> None:
         pass
 
     @abstractmethod


### PR DESCRIPTION
  ## Summary

  Add `telegram.delete_messages_on_remove` (default `false`). When enabled, removing a file or directory via TGFS also issues `messages.deleteMessages` for the backing channel messages — the file-descriptor message plus every content
  message of every version — instead of leaving them on the channel as the current behavior does.

  Default is `false`, so this is fully opt-in and behavior is unchanged unless explicitly enabled in config.

  ## Why

  The historical behavior leaves orphaned content messages in the private file channel after a TGFS-side delete, which is surprising for users who expect the channel to mirror the filesystem state, and can balloon channel size over time.
   This adds a way to keep the channel in sync without forcing the change on existing deployments.

  ## How it works

  - New `Telegram.delete_messages_on_remove` config field, plumbed into `MessageApi.delete_messages`.
  - `DirectoryApi.rm_empty` / `rm_dangerously` and `FileApi.rm` collect every message id they no longer reference (descriptor + content messages of every version) and forward them through `message_api.delete_messages`.
  - `delete_messages` dedupes ids, drops zero/negative ids, batches into Telegram's 100-ids-per-call limit, and **swallows errors** so a failed delete never rolls back the metadata change (deletes are best-effort by design).
  - Requires the bot to be admin of `private_file_channel` with the "Delete Messages" permission; otherwise the API call silently fails (still logged).

  ## Test plan

  - [x] New tests in `tests/tgfs/core/api/message/test_message_api.py` cover: flag disabled → no API call; enabled + happy path; empty/dedupe/batching; error swallowing.
  - [x] New `tests/tgfs/core/api/test_directory.py` covers `rm_empty` and `rm_dangerously` collecting subtree message ids.
  - [x] Existing `tests/tgfs/core/api/test_file.py` extended for the `FileApi.rm` path.
  - [x] `tests/tgfs/telegram/impl/test_telethon.py` covers the new telethon adapter method.
  - [x] All 94 tests in the touched suites pass on this branch. One unrelated pre-existing failure (`test_download_file_small`) reproduces on plain `master` and is not affected by this PR.

  ## Compatibility

  - Default `false` preserves current behavior verbatim.
  - Existing configs without the new field continue to work; the field is parsed with `data.get("delete_messages_on_remove", False)`.
