### PR TITLE
feat(model): track creation and modification timestamps on directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Refer to the [wiki page](https://github.com/TheodoreKrypton/tgfs/wiki/TGFS-Wiki)
 * Importing files that are already on Telegram (Only via the Telegram Mini App)
 * File size is unlimited (larger files are chunked into parts but appear as a single file to the user)
 * Live streaming of videos
+* Directories carry real creation and modification timestamps (persisted in the metadata and exposed over WebDAV)
 
 
 ## Demo Server

--- a/tests/tgfs/core/model/test_directory.py
+++ b/tests/tgfs/core/model/test_directory.py
@@ -1,3 +1,4 @@
+import datetime
 import pytest
 from unittest.mock import Mock
 
@@ -89,24 +90,48 @@ class TestTGFSDirectory:
             TGFSDirectory(name="invalid/name", parent=None)
 
     def test_created_at_timestamp_property(self):
-        # Test timestamp property (always returns FIRST_DAY_OF_EPOCH)
+        # Fresh directories get a real timestamp from the default factory.
         directory = TGFSDirectory(name="test", parent=None)
 
+        assert directory.created_at_timestamp > 0
+        assert abs(directory.created_at_timestamp - directory.modified_at_timestamp) < 1000
+
+    def test_legacy_from_dict_has_epoch_timestamps(self):
+        # Directories serialized before the timestamp fields existed deserialize at epoch.
+        directory = TGFSDirectory.from_dict(
+            {
+                "type": "D",
+                "name": "legacy",
+                "children": [],
+                "files": [],
+            }
+        )
+
         assert directory.created_at_timestamp == ts(FIRST_DAY_OF_EPOCH)
+        assert directory.modified_at_timestamp == ts(FIRST_DAY_OF_EPOCH)
 
     def test_to_dict_empty(self):
         # Test serialization of empty directory
         directory = TGFSDirectory(name="empty", parent=None)
 
         result = directory.to_dict()
-        expected = {
-            "type": "D",
-            "name": "empty",
-            "children": [],
-            "files": [],
-        }
 
-        assert result == expected
+        assert result["type"] == "D"
+        assert result["name"] == "empty"
+        assert result["children"] == []
+        assert result["files"] == []
+        assert result["createdAt"] == directory.created_at_timestamp
+        assert result["modifiedAt"] == directory.modified_at_timestamp
+
+    def test_to_from_dict_roundtrip_preserves_timestamps(self):
+        original = TGFSDirectory(name="rt", parent=None)
+        original.created_at = datetime.datetime(2024, 6, 1, 12, 30, 45)
+        original.modified_at = datetime.datetime(2024, 6, 2, 9, 15, 0)
+
+        restored = TGFSDirectory.from_dict(original.to_dict())
+
+        assert restored.created_at_timestamp == original.created_at_timestamp
+        assert restored.modified_at_timestamp == original.modified_at_timestamp
 
     def test_to_dict_with_content(self):
         # Test serialization with children and files
@@ -456,6 +481,49 @@ class TestTGFSDirectory:
 
         assert root.children == []
         assert root.files == []
+
+    def test_create_file_ref_bumps_modified_at(self):
+        parent = TGFSDirectory(name="parent", parent=None)
+        parent.created_at = datetime.datetime(2020, 1, 1)
+        parent.modified_at = datetime.datetime(2020, 1, 1)
+        original_created = parent.created_at_timestamp
+
+        parent.create_file_ref("new.txt", 1)
+
+        assert parent.modified_at_timestamp > original_created
+        assert parent.created_at_timestamp == original_created
+
+    def test_delete_file_ref_bumps_modified_at(self):
+        parent = TGFSDirectory(name="parent", parent=None)
+        fr = parent.create_file_ref("doomed.txt", 1)
+        parent.modified_at = datetime.datetime(2020, 1, 1)
+        stale = parent.modified_at_timestamp
+
+        parent.delete_file_ref(fr)
+
+        assert parent.modified_at_timestamp > stale
+
+    def test_child_delete_bumps_parent_modified_at(self):
+        parent = TGFSDirectory(name="parent", parent=None)
+        child = parent.create_dir("child", None)
+        parent.modified_at = datetime.datetime(2020, 1, 1)
+        stale = parent.modified_at_timestamp
+
+        child.delete()
+
+        assert parent.modified_at_timestamp > stale
+
+    def test_create_dir_stamps_fresh_timestamp_on_copy(self):
+        template = TGFSDirectory(name="template", parent=None)
+        template.created_at = datetime.datetime(2000, 1, 1)
+        template.modified_at = datetime.datetime(2000, 1, 1)
+        template_ts = template.created_at_timestamp
+
+        parent = TGFSDirectory(name="parent", parent=None)
+        copy_dir = parent.create_dir("copy", template)
+
+        assert copy_dir.created_at_timestamp > template_ts
+        assert copy_dir.modified_at_timestamp > template_ts
 
     def test_absolute_path_root(self):
         # Test absolute path for root directory

--- a/tgfs/app/webdav/folder.py
+++ b/tgfs/app/webdav/folder.py
@@ -76,7 +76,7 @@ class Folder(_Folder):
         return self.__folder.created_at_timestamp
 
     async def last_modified(self) -> int:
-        return self.__folder.created_at_timestamp
+        return self.__folder.modified_at_timestamp
 
     async def remove(self) -> None:
         self.fs_cache.reset_parent(self.__relative_path)

--- a/tgfs/core/model/directory.py
+++ b/tgfs/core/model/directory.py
@@ -1,3 +1,4 @@
+import datetime
 from dataclasses import dataclass, field
 from typing import Iterable, List, Optional, Self
 
@@ -31,18 +32,29 @@ class TGFSDirectory:
     parent: Optional["TGFSDirectory"]
     children: list["TGFSDirectory"] = field(default_factory=list)
     files: list[TGFSFileRef] = field(default_factory=list)
+    created_at: datetime.datetime = field(default_factory=datetime.datetime.now)
+    modified_at: datetime.datetime = field(default_factory=datetime.datetime.now)
 
     def __post_init__(self):
         validate_name(self.name)
 
     @property
     def created_at_timestamp(self) -> int:
-        return ts(FIRST_DAY_OF_EPOCH)
+        return ts(self.created_at)
+
+    @property
+    def modified_at_timestamp(self) -> int:
+        return ts(self.modified_at)
+
+    def _touch_modified(self) -> None:
+        self.modified_at = datetime.datetime.now()
 
     def to_dict(self) -> dict:
         return dict(
             type="D",
             name=self.name,
+            createdAt=self.created_at_timestamp,
+            modifiedAt=self.modified_at_timestamp,
             children=[child.to_dict() for child in self.children],
             files=[file.to_dict() for file in self.files],
         )
@@ -51,11 +63,19 @@ class TGFSDirectory:
     def from_dict(
         data: TGFSDirectorySerialized, parent: Optional["TGFSDirectory"] = None
     ) -> "TGFSDirectory":
+        def _read_ts(key: str) -> datetime.datetime:
+            value = data.get(key, 0) or 0
+            if value > 0:
+                return datetime.datetime.fromtimestamp(value / 1000)
+            return FIRST_DAY_OF_EPOCH
+
         d = TGFSDirectory(
             name=data["name"],
             parent=parent,
             children=[],
             files=[],
+            created_at=_read_ts("createdAt"),
+            modified_at=_read_ts("modifiedAt"),
         )
 
         if data["files"]:
@@ -82,6 +102,7 @@ class TGFSDirectory:
         )
 
         self.children.append(child)
+        self._touch_modified()
         return child
 
     @classmethod
@@ -120,18 +141,22 @@ class TGFSDirectory:
             location=self,
         )
         self.files.append(fr)
+        self._touch_modified()
         return fr
 
     def delete_file_ref(self, fr: TGFSFileRef) -> None:
         self.files.remove(fr)
+        self._touch_modified()
 
     def delete(self) -> None:
         if self.parent:
             self.parent.children.remove(self)
+            self.parent._touch_modified()
         else:
             # root directory, just clear its contents
             self.children.clear()
             self.files.clear()
+            self._touch_modified()
 
     @property
     def absolute_path(self) -> str:

--- a/tgfs/core/model/serialized.py
+++ b/tgfs/core/model/serialized.py
@@ -25,5 +25,7 @@ class TGFSFileRefSerialized(TypedDict, total=False):
 class TGFSDirectorySerialized(TypedDict, total=False):
     type: Literal["D"]
     name: str
+    createdAt: int
+    modifiedAt: int
     children: List["TGFSDirectorySerialized"]
     files: List[TGFSFileRefSerialized]


### PR DESCRIPTION
Directories used to share a hardcoded `created_at_timestamp` of `FIRST_DAY_OF_EPOCH`, so WebDAV clients displayed 1970-01-01 for every folder while files showed real dates. Store `created_at` and `modified_at` on `TGFSDirectory`, persist them through the serialized form (`createdAt` / `modifiedAt` in ms, optional fields so old metadata blobs deserialize unchanged), and expose `modified_at` as WebDAV `getlastmodified`.

`modified_at` is bumped on the directly affected directory whenever its contents change (file/subdir added or removed) — POSIX mtime semantics, no cascade up the tree. Legacy directories saved without timestamps continue to read back at the epoch until an organic write pushes a fresh timestamp.